### PR TITLE
Adds Program Outputs to Irida Next JSON Output File

### DIFF
--- a/conf/iridanext.config
+++ b/conf/iridanext.config
@@ -13,6 +13,8 @@ iridanext {
                 "**/distances/profile_dists.results.text",
                 "**/distances/profile_dists.run.json",
                 "**/merged/locidex.merge.profile.tsv",
+                "**/process/results.tsv",
+                "**/process/results.xlsx"
             ]
         }
     }

--- a/tests/pipelines/main.nf.test
+++ b/tests/pipelines/main.nf.test
@@ -87,6 +87,8 @@ nextflow_pipeline {
             assert iridanext_global.findAll { it.path == "distances/profile_dists.query_profile.text" }.size() == 1
             assert iridanext_global.findAll { it.path == "distances/profile_dists.allele_map.json" }.size() == 1
             assert iridanext_global.findAll { it.path == "merged/locidex.merge.profile.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "process/results.xlsx" }.size() == 1
+            assert iridanext_global.findAll { it.path == "process/results.tsv" }.size() == 1
 
             assert iridanext_samples.isEmpty()
             assert iridanext_metadata.isEmpty()
@@ -226,6 +228,8 @@ nextflow_pipeline {
             assert iridanext_global.findAll { it.path == "distances/profile_dists.query_profile.text" }.size() == 1
             assert iridanext_global.findAll { it.path == "distances/profile_dists.allele_map.json" }.size() == 1
             assert iridanext_global.findAll { it.path == "merged/locidex.merge.profile.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "process/results.xlsx" }.size() == 1
+            assert iridanext_global.findAll { it.path == "process/results.tsv" }.size() == 1
 
             assert iridanext_samples.isEmpty()
             assert iridanext_metadata.isEmpty()
@@ -273,6 +277,8 @@ nextflow_pipeline {
             assert iridanext_global.findAll { it.path == "distances/profile_dists.query_profile.text" }.size() == 1
             assert iridanext_global.findAll { it.path == "distances/profile_dists.allele_map.json" }.size() == 1
             assert iridanext_global.findAll { it.path == "merged/locidex.merge.profile.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "process/results.xlsx" }.size() == 1
+            assert iridanext_global.findAll { it.path == "process/results.tsv" }.size() == 1
 
             assert iridanext_samples.isEmpty()
             assert iridanext_metadata.isEmpty()
@@ -334,6 +340,8 @@ nextflow_pipeline {
             assert iridanext_global.findAll { it.path == "distances/profile_dists.query_profile.text" }.size() == 1
             assert iridanext_global.findAll { it.path == "distances/profile_dists.allele_map.json" }.size() == 1
             assert iridanext_global.findAll { it.path == "merged/locidex.merge.profile.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "process/results.xlsx" }.size() == 1
+            assert iridanext_global.findAll { it.path == "process/results.tsv" }.size() == 1
 
             assert iridanext_samples.isEmpty()
             assert iridanext_metadata.isEmpty()
@@ -392,6 +400,8 @@ nextflow_pipeline {
             assert iridanext_global.findAll { it.path == "distances/profile_dists.query_profile.text" }.size() == 1
             assert iridanext_global.findAll { it.path == "distances/profile_dists.allele_map.json" }.size() == 1
             assert iridanext_global.findAll { it.path == "merged/locidex.merge.profile.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "process/results.xlsx" }.size() == 1
+            assert iridanext_global.findAll { it.path == "process/results.tsv" }.size() == 1
 
             assert iridanext_samples.isEmpty()
             assert iridanext_metadata.isEmpty()
@@ -444,6 +454,8 @@ nextflow_pipeline {
             assert iridanext_global.findAll { it.path == "distances/profile_dists.query_profile.text" }.size() == 1
             assert iridanext_global.findAll { it.path == "distances/profile_dists.allele_map.json" }.size() == 1
             assert iridanext_global.findAll { it.path == "merged/locidex.merge.profile.tsv" }.size() == 1
+            assert iridanext_global.findAll { it.path == "process/results.xlsx" }.size() == 1
+            assert iridanext_global.findAll { it.path == "process/results.tsv" }.size() == 1
 
             assert iridanext_samples.isEmpty()
             assert iridanext_metadata.isEmpty()


### PR DESCRIPTION
I added both TSV and XLSX, because it's a pain trying to use XLSX when you don't have Excel or something that opens those files.

Output:

```
{
    "files": {
        "global": [
            {
                "path": "process/results.xlsx"
            },
            {
                "path": "process/results.tsv"
            },
            {
                "path": "distances/profile_dists.run.json"
            },
            {
                "path": "distances/profile_dists.results.text"
            },
            {
                "path": "distances/profile_dists.ref_profile.text"
            },
            {
                "path": "distances/profile_dists.query_profile.text"
            },
            {
                "path": "distances/profile_dists.allele_map.json"
            },
            {
                "path": "merged/locidex.merge.profile.tsv"
            }
        ],
        "samples": {
            
        }
    },
    "metadata": {
        "samples": {
            
        }
    }
}
```