### PR TITLE
Update fastmatch threshold

### DIFF
--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -11,6 +11,8 @@ lint:
     - lib/WorkflowMain.groovy
     - lib/NfcoreTemplate.groovy
     - lib/Workflowfastmatchirida.groovy
+    - conf/igenomes_ignored.config
+    - ro-crate-metadata.json
   files_unchanged:
     - assets/sendmail_template.txt
     - assets/email_template.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Changed`
 
 - Changed file extensions (`.text` -> `.tsv`) of output files from `GAS_MCLUSTER` and `PROFILE_DISTS` found in the `iridanext.output.json`. Output files are now compatiable with file preview feature in IRIDA Next. [PR 10](https://github.com/phac-nml/fastmatchirida/pull/10)
+- Changed the default threshold for minimum matching alleles from 1 to 50 for filtering. The idea being to show more results and let user filter themselves after. [PR 12](https://github.com/phac-nml/fastmatchirida/pull/12)
 
 ### `Updated`
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ The structure of this file is defined in [assets/schema_input.json](assets/schem
 
 # Parameters
 
-The main parameters are `--input` as defined above and `--output` for specifying the output results directory. You may wish to provide `-profile singularity` to specify the use of singularity containers and `-r [branch]` to specify which GitHub branch you would like to run.
+The main parameters are `--threshold`, `--input` as defined above and `--output` for specifying the output results directory. You may wish to provide `-profile singularity` to specify the use of singularity containers and `-r [branch]` to specify which GitHub branch you would like to run.
+
+- `--threshold` the minimum alleles for filtering matches (default: 50)
 
 ## Metadata
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -44,7 +44,7 @@ params {
     validate_params                  = true
 
     // FastMatch
-    threshold = 1.0
+    threshold = 50.0
 
     // Profile dists args
     pd_distm = "hamming"
@@ -223,7 +223,7 @@ manifest {
     name            = 'phac-nml/fastmatchirida'
     author          = """Aaron Petkau, Eric Marinier, Matthew Wells and Steven Sutcliffe"""
     homePage        = 'https://github.com/phac-nml/fastmatchirida'
-    description     = """IRIDA Next Genomic Address Service Clustering Pipeline"""
+    description     = """Fastmatchiridia pipeline filters MLST files that are sufficiently within a specified distance of each other"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
     version         = '0.2.0'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft-07/schema",
     "$id": "https://raw.githubusercontent.com/phac-nml/fastmatchirida/main/nextflow_schema.json",
     "title": "phac-nml/fastmatchirida pipeline parameters",
-    "description": "IRIDA Next Example Pipeline",
+    "description": "Fastmatchiridia pipeline filters MLST files that are sufficiently within a specified distance of each other",
     "type": "object",
     "definitions": {
         "input_output_options": {
@@ -113,7 +113,7 @@
                 "threshold": {
                     "type": "number",
                     "description": "Comparison score threshold value",
-                    "default": 1.0,
+                    "default": 50.0,
                     "minimum": 0
                 }
             }


### PR DESCRIPTION
## STRY0017608: Update default filter threshold

### Description

The current default is 1 allele for filtering but usually a higher threshold is used for filtering. We will increase the threshold to be 50 alleles as this is the reasonable upper limit for what would be used. Users can always filter down results after or manually adjust to be lower as needed.

### Additional

Fixed some nf-core linting issues.

<!--
# phac-nml/fastmatchirida pull request

Many thanks for contributing to phac-nml/fastmatchirida!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/phac-nml/fastmatchirida/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
