### PR TITLE
Update/profile dists to 1.0.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,11 @@ jobs:
           sudo mv nf-test /usr/local/bin/
 
       - name: Run nf-test
+        continue-on-error: ${{ matrix.NXF_VER == 'latest-everything' }}
         run: |
           nf-test test
 
       - name: Nextflow run with test profile
+        continue-on-error: ${{ matrix.NXF_VER == 'latest-everything' }}
         run: |
           nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Update`
 
-- Update `profile_dists` to [1.0.5](https://github.com/phac-nml/profile_dists/releases/tag/1.0.5). [PR 13](https://github.com/phac-nml/fastmatchirida/pull/13)
+- Update `profile_dists` to [1.0.5](https://github.com/phac-nml/profile_dists/releases/tag/1.0.5). [PR 14](https://github.com/phac-nml/fastmatchirida/pull/14)
 
 ### `Add`
 
-- Add `software_versions.yml` to `iridanext.output.json.gz` global files. [PR 13](https://github.com/phac-nml/fastmatchirida/pull/13)
+- Add `software_versions.yml` to `iridanext.output.json.gz` global files. [PR 14](https://github.com/phac-nml/fastmatchirida/pull/14)
 
 ## [0.2.0] - 2025-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2025-05-dd
+
+### `Update`
+
+- Update `profile_dists` to [1.0.5](https://github.com/phac-nml/profile_dists/releases/tag/1.0.5). [PR 13](https://github.com/phac-nml/fastmatchirida/pull/13)
+
+### `Add`
+
+- Add `software_versions.yml` to `iridanext.output.json.gz` global files. [PR 13](https://github.com/phac-nml/fastmatchirida/pull/13)
+
 ## [0.2.0] - 2025-04-09
 
 ### `Changed`
@@ -25,3 +35,4 @@ fastmatchirida is built using Gasclustering [0.4.0] as a template. Set up the ba
 [0.1.1]: https://github.com/phac-nml/fastmatchirida/releases/tag/0.1.1
 [0.1.0]: https://github.com/phac-nml/fastmatchirida/releases/tag/0.1.0
 [0.2.0]: https://github.com/phac-nml/fastmatchirida/releases/tag/0.2.0
+[0.2.1]: https://github.com/phac-nml/fastmatchirida/releases/tag/0.2.1

--- a/conf/iridanext.config
+++ b/conf/iridanext.config
@@ -14,7 +14,8 @@ iridanext {
                 "**/distances/profile_dists.run.json",
                 "**/merged/locidex.merge.profile.tsv",
                 "**/process/results.tsv",
-                "**/process/results.xlsx"
+                "**/process/results.xlsx",
+                "**/pipeline_info/software_versions.yml"
             ]
         }
     }

--- a/modules/local/profile_dists/main.nf
+++ b/modules/local/profile_dists/main.nf
@@ -3,8 +3,8 @@ process PROFILE_DISTS{
     tag "Pairwise Distance Generation"
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/profile_dists%3A1.0.4--pyhdfd78af_0' :
-        'biocontainers/profile_dists:1.0.4--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/profile_dists%3A1.0.5--pyhdfd78af_0' :
+        'biocontainers/profile_dists:1.0.5--pyhdfd78af_0' }"
 
     input:
     path query

--- a/nextflow.config
+++ b/nextflow.config
@@ -226,7 +226,7 @@ manifest {
     description     = """Fastmatchiridia pipeline filters MLST files that are sufficiently within a specified distance of each other"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '0.2.0'
+    version         = '0.2.1'
     doi             = ''
     defaultBranch   = 'main'
 }


### PR DESCRIPTION
## STRY0017940: Update profile_dists with additional fixes

## Description:

Latest versions [1.0.5](https://github.com/phac-nml/profile_dists/releases/tag/1.0.5) of `profile_dists` so that calculations are correct.

## Acceptance Criteria:

- [x] Update profile_dists to latest version
- [x] Make sure tests still work

## Note:

Also added the software version file to global files to be included in IRIDA-Next

<!--
# phac-nml/fastmatchirida pull request

Many thanks for contributing to phac-nml/fastmatchirida!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/phac-nml/fastmatchirida/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
