### PR TITLE
Fix issue #19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.1] - 2025-05-dd
 
+### `Fixes`
+
 - Fix Issue [#19](https://github.com/phac-nml/fastmatchirida/issues/19) by providing a new process `copyFile` to rename duplicate MLST files. [PR 18](https://github.com/phac-nml/fastmatchirida/pull/18)
+- Fix Issue [#18](https://github.com/phac-nml/fastmatchirida/issues/18) changing input type for `merge_tsv`. [PR 18](https://github.com/phac-nml/fastmatchirida/pull/18)
 
 ## [0.3.0] - 2025-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.1] - 2025-05-dd
+## [0.3.1] - 2025-05-22
 
 ### `Fixes`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2025-05-dd
+
+- Fix Issue [#19](https://github.com/phac-nml/fastmatchirida/issues/19) by providing a new process `copyFile` to rename duplicate MLST files. [PR 18](https://github.com/phac-nml/fastmatchirida/pull/18)
+
 ## [0.3.0] - 2025-05-08
 
 ### `Update`
@@ -46,3 +50,4 @@ fastmatchirida is built using Gasclustering [0.4.0] as a template. Set up the ba
 [0.1.0]: https://github.com/phac-nml/fastmatchirida/releases/tag/0.1.0
 [0.2.0]: https://github.com/phac-nml/fastmatchirida/releases/tag/0.2.0
 [0.3.0]: https://github.com/phac-nml/fastmatchirida/releases/tag/0.3.0
+[0.3.1]: https://github.com/phac-nml/fastmatchirida/releases/tag/0.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Issue [#19](https://github.com/phac-nml/fastmatchirida/issues/19) by providing a new process `copyFile` to rename duplicate MLST files. [PR 18](https://github.com/phac-nml/fastmatchirida/pull/18)
 - Fix Issue [#18](https://github.com/phac-nml/fastmatchirida/issues/18) changing input type for `merge_tsv`. [PR 18](https://github.com/phac-nml/fastmatchirida/pull/18)
 
+### `Updated`
+
+- Update `profile_dists` to `v.1.0.6`. [PR 18](https://github.com/phac-nml/fastmatchirida/pull/18)
+
 ## [0.3.0] - 2025-05-08
 
 ### `Update`

--- a/modules/local/copyFile/main.nf
+++ b/modules/local/copyFile/main.nf
@@ -1,0 +1,15 @@
+    process COPY_FILE {
+    tag 'Copy and Rename file'
+    label "process_single"
+
+    input:
+    tuple val(meta), path(original_file), val(uniqueMLST)
+
+    output:
+    tuple val(meta), path("${meta.id}_${original_file}")
+
+    script:
+    """
+    cp $original_file ${meta.id}_${original_file}
+    """
+}

--- a/modules/local/copyFile/main.nf
+++ b/modules/local/copyFile/main.nf
@@ -1,4 +1,4 @@
-    process COPY_FILE {
+process COPY_FILE {
     tag 'Copy and Rename file'
     label "process_single"
 

--- a/modules/local/locidex/merge/main.nf
+++ b/modules/local/locidex/merge/main.nf
@@ -13,7 +13,7 @@ process LOCIDEX_MERGE {
     input:
     tuple val(batch_index), path(input_values) // [file(sample1), file(sample2), file(sample3), etc...]
     val  input_tag    // makes output unique and denotes the item as the reference or query to prevent name collision
-    val  merge_tsv
+    path  merge_tsv
 
     output:
     path("${input_tag}/profile_${batch_index}.tsv"),           emit: combined_profiles

--- a/modules/local/profile_dists/main.nf
+++ b/modules/local/profile_dists/main.nf
@@ -3,8 +3,8 @@ process PROFILE_DISTS{
     tag "Pairwise Distance Generation"
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/profile_dists%3A1.0.5--pyhdfd78af_0' :
-        'biocontainers/profile_dists:1.0.5--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/profile_dists%3A1.0.6--pyhdfd78af_0' :
+        'biocontainers/profile_dists:1.0.6--pyhdfd78af_0' }"
 
     input:
     path query

--- a/nextflow.config
+++ b/nextflow.config
@@ -229,7 +229,7 @@ manifest {
     description     = """Fastmatchiridia pipeline filters MLST files that are sufficiently within a specified distance of each other"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '0.3.0'
+    version         = '0.3.1'
     doi             = ''
     defaultBranch   = 'main'
 }

--- a/tests/data/samplesheets/samplesheet-samplename.csv
+++ b/tests/data/samplesheets/samplesheet-samplename.csv
@@ -1,0 +1,6 @@
+sample,sample_name,fastmatch_category,mlst_alleles
+sample1,sampleX,query,https://raw.githubusercontent.com/phac-nml/fastmatchirida/dev/tests/data/mlst/sample1.mlst.json
+sample2,sampleX,,https://raw.githubusercontent.com/phac-nml/fastmatchirida/dev/tests/data/mlst/sample1.mlst.json
+sample3,sampleY,reference,https://raw.githubusercontent.com/phac-nml/fastmatchirida/dev/tests/data/mlst/sample3.mlst.json
+sample4,sampleZ,reference,https://raw.githubusercontent.com/phac-nml/fastmatchirida/dev/tests/data/mlst/sample4.mlst.json
+sample5,sampleP,reference,https://raw.githubusercontent.com/phac-nml/fastmatchirida/dev/tests/data/mlst/sample4.mlst.json

--- a/tests/pipelines/integration.nf.test
+++ b/tests/pipelines/integration.nf.test
@@ -1143,8 +1143,8 @@ nextflow_pipeline {
 
             // The merge_tsv file used in renaming the MLST profiles in locidex merge has the right file paths
             def merge_tsv_content = path("$launchDir/results/write/results.csv")
-            assert merge_tsv_content.text.contains("/sampleX_sample2_sample1.mlst.json") // The file path (minus the work directory)
-            assert merge_tsv_content.text.contains("/sampleP_sample4.mlst.json") // The file path (minus the work directory)
+            assert merge_tsv_content.text.split('\n').any { line -> line ==~ /^sampleX_sample2.*\/sampleX_sample2_sample1\.mlst\.json$/} // The file path (minus the work directory)
+            assert merge_tsv_content.text.split('\n').any { line -> line ==~ /^sampleP.*\/sampleP_sample4\.mlst\.json$/}
         }
     }
 }

--- a/tests/pipelines/integration.nf.test
+++ b/tests/pipelines/integration.nf.test
@@ -1134,12 +1134,12 @@ nextflow_pipeline {
             assert workflow.success
             assert path("$launchDir/results").exists()
 
-            // Check that the CopyFile process was called for the correct samples
-            assert path("$launchDir/results/copyfile/sampleX_sample2_sample1.mlst.json").exists()
-            assert !path("$launchDir/results/copyfile/sampleX_sample1.mlst.json").exists()
-            assert !path("$launchDir/results/copyfile/sampleY_sample3.mlst.json").exists()
-            assert !path("$launchDir/results/copyfile/sampleZ_sample4.mlst.json").exists()
-            assert path("$launchDir/results/copyfile/sampleP_sample4.mlst.json").exists()
+            // Check that the COPY_FILE process was called for the correct samples
+            assert path("$launchDir/results/copy/sampleX_sample2_sample1.mlst.json").exists()
+            assert !path("$launchDir/results/copy/sampleX_sample1.mlst.json").exists()
+            assert !path("$launchDir/results/copy/sampleY_sample3.mlst.json").exists()
+            assert !path("$launchDir/results/copy/sampleZ_sample4.mlst.json").exists()
+            assert path("$launchDir/results/copy/sampleP_sample4.mlst.json").exists()
 
             // The merge_tsv file used in renaming the MLST profiles in locidex merge has the right file paths
             def merge_tsv_content = path("$launchDir/results/write/results.csv")

--- a/tests/pipelines/integration.nf.test
+++ b/tests/pipelines/integration.nf.test
@@ -1145,6 +1145,19 @@ nextflow_pipeline {
             def merge_tsv_content = path("$launchDir/results/write/results.csv")
             assert merge_tsv_content.text.split('\n').any { line -> line ==~ /^sampleX_sample2.*\/sampleX_sample2_sample1\.mlst\.json$/} // The file path (minus the work directory)
             assert merge_tsv_content.text.split('\n').any { line -> line ==~ /^sampleP.*\/sampleP_sample4\.mlst\.json$/}
+
+            // Check Processed Output
+            def processed_output_tsv = path("$launchDir/results/process/results.tsv")
+            assert processed_output_tsv.exists()
+            def processed_output_xlsx = path("$launchDir/results/process/results.xlsx")
+            assert processed_output_xlsx.exists()
+
+            assert processed_output_tsv.text.contains("Query ID\tQuery Sample Name\tReference ID\tReference Sample Name\tDistance\tmetadata_1\tmetadata_2\tmetadata_3\tmetadata_4\tmetadata_5\tmetadata_6\tmetadata_7\tmetadata_8")
+            assert processed_output_tsv.text.contains("sample1\tsampleX\tsample2\tsampleX_sample2\t0")
+            assert processed_output_tsv.text.contains("sample1\tsampleX\tsample1\tsampleX\t0")
+            assert processed_output_tsv.text.contains("sample1\tsampleX\tsample3\tsampleY\t1")
+            assert processed_output_tsv.text.contains("sample1\tsampleX\tsample4\tsampleZ\t1")
+            assert processed_output_tsv.text.contains("sample1\tsampleX\tsample5\tsampleP\t1")
         }
     }
 }

--- a/tests/pipelines/integration.nf.test
+++ b/tests/pipelines/integration.nf.test
@@ -1117,4 +1117,34 @@ nextflow_pipeline {
             assert error_report_query == error_report
         }
     }
+
+    test("Testing for when there are repeat MLST allele files"){
+        // Previous versions of the pipeline would fail if there were repeat MLST allele files in the samplesheet.
+        tag "repeat-mlst"
+
+        when{
+            params {
+                input = "$baseDir/tests/data/samplesheets/samplesheet-samplename.csv"
+                outdir = "results"
+                batch_size = 1
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert path("$launchDir/results").exists()
+
+            // Check that the CopyFile process was called for the correct samples
+            assert path("$launchDir/results/copyfile/sampleX_sample2_sample1.mlst.json").exists()
+            assert !path("$launchDir/results/copyfile/sampleX_sample1.mlst.json").exists()
+            assert !path("$launchDir/results/copyfile/sampleY_sample3.mlst.json").exists()
+            assert !path("$launchDir/results/copyfile/sampleZ_sample4.mlst.json").exists()
+            assert path("$launchDir/results/copyfile/sampleP_sample4.mlst.json").exists()
+
+            // The merge_tsv file used in renaming the MLST profiles in locidex merge has the right file paths
+            def merge_tsv_content = path("$launchDir/results/write/results.csv")
+            assert merge_tsv_content.text.contains("/sampleX_sample2_sample1.mlst.json") // The file path (minus the work directory)
+            assert merge_tsv_content.text.contains("/sampleP_sample4.mlst.json") // The file path (minus the work directory)
+        }
+    }
 }

--- a/tests/pipelines/integration.nf.test
+++ b/tests/pipelines/integration.nf.test
@@ -1118,7 +1118,7 @@ nextflow_pipeline {
         }
     }
 
-    test("Testing for when there are repeat MLST allele files"){
+    test("Testing for when there are repeat MLST allele files in multiple batches"){
         // Previous versions of the pipeline would fail if there were repeat MLST allele files in the samplesheet.
         tag "repeat-mlst"
 
@@ -1160,4 +1160,48 @@ nextflow_pipeline {
             assert processed_output_tsv.text.contains("sample1\tsampleX\tsample5\tsampleP\t1")
         }
     }
+
+    test("Testing for when there are repeat MLST allele files in one single batch"){
+        // Previous versions of the pipeline would fail if there were repeat MLST allele files in the samplesheet.
+        tag "repeat-mlst-single-batch"
+
+        when{
+            params {
+                input = "$baseDir/tests/data/samplesheets/samplesheet-samplename.csv"
+                outdir = "results"
+                batch_size = 10
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert path("$launchDir/results").exists()
+
+            // Check that the COPY_FILE process was called for the correct samples
+            assert path("$launchDir/results/copy/sampleX_sample2_sample1.mlst.json").exists()
+            assert !path("$launchDir/results/copy/sampleX_sample1.mlst.json").exists()
+            assert !path("$launchDir/results/copy/sampleY_sample3.mlst.json").exists()
+            assert !path("$launchDir/results/copy/sampleZ_sample4.mlst.json").exists()
+            assert path("$launchDir/results/copy/sampleP_sample4.mlst.json").exists()
+
+            // The merge_tsv file used in renaming the MLST profiles in locidex merge has the right file paths
+            def merge_tsv_content = path("$launchDir/results/write/results.csv")
+            assert merge_tsv_content.text.split('\n').any { line -> line ==~ /^sampleX_sample2.*\/sampleX_sample2_sample1\.mlst\.json$/} // The file path (minus the work directory)
+            assert merge_tsv_content.text.split('\n').any { line -> line ==~ /^sampleP.*\/sampleP_sample4\.mlst\.json$/}
+
+            // Check Processed Output
+            def processed_output_tsv = path("$launchDir/results/process/results.tsv")
+            assert processed_output_tsv.exists()
+            def processed_output_xlsx = path("$launchDir/results/process/results.xlsx")
+            assert processed_output_xlsx.exists()
+
+            assert processed_output_tsv.text.contains("Query ID\tQuery Sample Name\tReference ID\tReference Sample Name\tDistance\tmetadata_1\tmetadata_2\tmetadata_3\tmetadata_4\tmetadata_5\tmetadata_6\tmetadata_7\tmetadata_8")
+            assert processed_output_tsv.text.contains("sample1\tsampleX\tsample2\tsampleX_sample2\t0")
+            assert processed_output_tsv.text.contains("sample1\tsampleX\tsample1\tsampleX\t0")
+            assert processed_output_tsv.text.contains("sample1\tsampleX\tsample3\tsampleY\t1")
+            assert processed_output_tsv.text.contains("sample1\tsampleX\tsample4\tsampleZ\t1")
+            assert processed_output_tsv.text.contains("sample1\tsampleX\tsample5\tsampleP\t1")
+        }
+    }
+
 }

--- a/workflows/fastmatchirida.nf
+++ b/workflows/fastmatchirida.nf
@@ -28,6 +28,7 @@ Workflowfastmatchirida.initialise(params, log)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 include { WRITE_METADATA                         } from '../modules/local/write/main'
+include { COPY_FILE                              } from '../modules/local/copyFile/main'
 include { LOCIDEX_MERGE as LOCIDEX_MERGE_REF     } from '../modules/local/locidex/merge/main'
 include { LOCIDEX_MERGE as LOCIDEX_MERGE_QUERY   } from '../modules/local/locidex/merge/main'
 include { LOCIDEX_CONCAT as LOCIDEX_CONCAT_QUERY } from '../modules/local/locidex/concat/main'
@@ -67,19 +68,6 @@ def prepareFilePath(String filep){
     }
 
     return return_path // empty value if file argument is null
-}
-
-    process copyFile {
-    input:
-    tuple val(meta), path(original_file), val(uniqueMLST)
-
-    output:
-    tuple val(meta), path("${meta.id}_$original_file")
-
-    script:
-    """
-    cp $original_file ${meta.id}_$original_file
-    """
 }
 
 workflow FASTMATCH {
@@ -126,7 +114,7 @@ workflow FASTMATCH {
             keep: uniqueMLST == true // Keep the unique MLST files as is
             replace: uniqueMLST == false // Rename the non-unique MLST files to avoid collisions
         }.set {mlst_file_rename}
-    renamed_input = copyFile(mlst_file_rename.replace)
+    renamed_input = COPY_FILE(mlst_file_rename.replace)
     unchanged_input = mlst_file_rename.keep
         .map { meta, mlst_file, uniqueMLST ->
             tuple(meta, mlst_file) }

--- a/workflows/fastmatchirida.nf
+++ b/workflows/fastmatchirida.nf
@@ -123,8 +123,8 @@ workflow FASTMATCH {
     // For the MLST files that are not unique, rename them
     pre_input
         .branch { meta, mlst_file, uniqueMLST ->
-        keep: uniqueMLST == true
-        replace: uniqueMLST == false
+            keep: uniqueMLST == true // Keep the unique MLST files as is
+            replace: uniqueMLST == false // Rename the non-unique MLST files to avoid collisions
         }.set {mlst_file_rename}
     renamed_input = copyFile(mlst_file_rename.replace)
     unchanged_input = mlst_file_rename.keep

--- a/workflows/fastmatchirida.nf
+++ b/workflows/fastmatchirida.nf
@@ -69,17 +69,31 @@ def prepareFilePath(String filep){
     return return_path // empty value if file argument is null
 }
 
+    process copyFile {
+    input:
+    tuple val(meta), path(original_file), val(uniqueMLST)
+
+    output:
+    tuple val(meta), path("${meta.id}_$original_file")
+
+    script:
+    """
+    cp $original_file ${meta.id}_$original_file
+    """
+}
+
 workflow FASTMATCH {
     SAMPLE_HEADER = "sample"
     ch_versions = Channel.empty()
-    // Track processed IDs
-    def processedIDs = [] as Set
-
+    // Track processed IDs and MLST files
+    def processedIDs  = [] as Set
+    def processedMLST  = [] as Set
     // Create a new channel of metadata from a sample sheet
     // NB: `input` corresponds to `params.input` and associated sample sheet schema
-    input = Channel.fromSamplesheet("input")
+    pre_input = Channel.fromSamplesheet("input")
     // and remove non-alphanumeric characters in sample_names (meta.id), whilst also correcting for duplicate sample_names (meta.id)
     .map { meta, mlst_file, ref_query ->
+            uniqueMLST = true
             if (!meta.id) {
                 meta.id = meta.irida_id
             } else {
@@ -89,19 +103,36 @@ workflow FASTMATCH {
             // Ensure ID is unique by appending meta.irida_id if needed
             while (processedIDs.contains(meta.id)) {
                 meta.id = "${meta.id}_${meta.irida_id}"
+
+            }
+            // Check if the MLST file is unique
+            if (processedMLST.contains(mlst_file)) {
+                uniqueMLST = false
             }
             // Add the ID to the set of processed IDs
             processedIDs << meta.id
+            processedMLST << mlst_file
             // If the fastmatch_category is blank make the default "reference"
             if (!ref_query) {
                 meta.ref_query = "reference"
             } else {
                 meta.ref_query = ref_query
             }
-            tuple(meta, mlst_file)}.loadIridaSampleIds()
+            tuple(meta, mlst_file, uniqueMLST)}.loadIridaSampleIds()
+
+    // For the MLST files that are not unique, rename them
+    pre_input
+        .branch { meta, mlst_file, uniqueMLST ->
+        keep: uniqueMLST == true
+        replace: uniqueMLST == false
+        }.set {mlst_file_rename}
+    renamed_input = copyFile(mlst_file_rename.replace)
+    unchanged_input = mlst_file_rename.keep
+        .map { meta, mlst_file, uniqueMLST ->
+            tuple(meta, mlst_file) }
+    input = unchanged_input.mix(renamed_input)
 
     // Metadata formatting
-
     metadata_headers = Channel.of(
         tuple(
             SAMPLE_HEADER,


### PR DESCRIPTION
# Issue #19

Allow for multiple samples to include the same MLST files.

## Descripton

As seen in the issue when samplesheets had samples with the same MLST file provided 

```
sample,sample_name,fastmatch_category,mlst_alleles
sample1,sampleX,query,https://raw.githubusercontent.com/phac-nml/fastmatchirida/dev/tests/data/mlst/sample1.mlst.json
sample2,sampleX,,https://raw.githubusercontent.com/phac-nml/fastmatchirida/dev/tests/data/mlst/sample1.mlst.json
sample3,sampleY,reference,https://raw.githubusercontent.com/phac-nml/fastmatchirida/dev/tests/data/mlst/sample3.mlst.json
sample4,sampleZ,reference,https://raw.githubusercontent.com/phac-nml/fastmatchirida/dev/tests/data/mlst/sample4.mlst.json
sample5,sampleZ,reference,https://raw.githubusercontent.com/phac-nml/fastmatchirida/dev/tests/data/mlst/sample5.mlst.json
```
Two types of errors would be generated. If the two same named MLST files were past to LOCIDEX_MERGE the error would occur there, or if in different batches then the error would occur downstream in PROFILE_DISTS

# Issue #18

Change the input type for `merge_tsv` to `path` not `val`

<!--
# phac-nml/fastmatchirida pull request

Many thanks for contributing to phac-nml/fastmatchirida!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/phac-nml/fastmatchirida/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] `CHANGELOG.md` is updated.
