### PR TITLE
Patch/copy file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,20 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2025-05-23
+
+- Added `baseName` to the check for repeat MLST allele files (in case file paths are different). [PR 22](https://github.com/phac-nml/fastmatchirida/pull/22)
+
 ## [0.3.1] - 2025-05-23
 
 ### `Fixes`
 
-- Fix Issue [#19](https://github.com/phac-nml/fastmatchirida/issues/19) by providing a new process `copyFile` to rename duplicate MLST files. [PR 18](https://github.com/phac-nml/fastmatchirida/pull/18)
-- Fix Issue [#18](https://github.com/phac-nml/fastmatchirida/issues/18) changing input type for `merge_tsv`. [PR 18](https://github.com/phac-nml/fastmatchirida/pull/18)
+- Fix Issue [#19](https://github.com/phac-nml/fastmatchirida/issues/19) by providing a new process `copyFile` to rename duplicate MLST files. [PR 20](https://github.com/phac-nml/fastmatchirida/pull/20)
+- Fix Issue [#18](https://github.com/phac-nml/fastmatchirida/issues/18) changing input type for `merge_tsv`. [PR 20](https://github.com/phac-nml/fastmatchirida/pull/20)
 
 ### `Updated`
 
-- Update `profile_dists` to `v.1.0.6`. [PR 18](https://github.com/phac-nml/fastmatchirida/pull/18)
+- Update `profile_dists` to `v.1.0.6`. [PR 20](https://github.com/phac-nml/fastmatchirida/pull/20)
 
 ## [0.3.0] - 2025-05-08
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -229,7 +229,7 @@ manifest {
     description     = """Fastmatchiridia pipeline filters MLST files that are sufficiently within a specified distance of each other"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '0.3.1'
+    version         = '0.3.2'
     doi             = ''
     defaultBranch   = 'main'
 }

--- a/workflows/fastmatchirida.nf
+++ b/workflows/fastmatchirida.nf
@@ -94,12 +94,12 @@ workflow FASTMATCH {
 
             }
             // Check if the MLST file is unique
-            if (processedMLST.contains(mlst_file)) {
+            if (processedMLST.contains(mlst_file.baseName)) {
                 uniqueMLST = false
             }
             // Add the ID to the set of processed IDs
             processedIDs << meta.id
-            processedMLST << mlst_file
+            processedMLST << mlst_file.baseName
             // If the fastmatch_category is blank make the default "reference"
             if (!ref_query) {
                 meta.ref_query = "reference"


### PR DESCRIPTION
Added `baseName` to the check for repeat MLST allele files. LOCIDEX_MERGE strips them of their path before running so it will error out even if files come from a unique filepath.
