### PR TITLE
Release: 0.4.1 Locidex Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,19 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2025-09-03
+
+### `Updated`
+
+- Upgraded `locidex` to [v.0.4.0](https://github.com/phac-nml/locidex/releases/tag/v0.4.0). [PR 33](https://github.com/phac-nml/fastmatchirida/pull/33)
+
+### `Added`
+
+- Added a process level `nf-test` for `LOCIDEX_MERGE` to confirm backward compatibility between MLST JSON files with and without a `"manfiest"` key. [PR 33](https://github.com/phac-nml/fastmatchirida/pull/33)
+
 ## [0.4.0] - 2025-08-11
 
-### Changed
+### `Changed`
 
 - The number of metadata columns in the sample sheet has been increased from 8 to 16. [PR 28](https://github.com/phac-nml/fastmatchirida/pull/28)
 
@@ -83,3 +93,4 @@ fastmatchirida is built using Gasclustering [0.4.0] as a template. Set up the ba
 [0.3.2]: https://github.com/phac-nml/fastmatchirida/releases/tag/0.3.2
 [0.3.3]: https://github.com/phac-nml/fastmatchirida/releases/tag/0.3.3
 [0.4.0]: https://github.com/phac-nml/fastmatchirida/releases/tag/0.4.0
+[0.4.1]: https://github.com/phac-nml/fastmatchirida/releases/tag/0.4.1

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -30,6 +30,7 @@ process {
     ]
 
     withName: LOCIDEX_MERGE_REF {
+        containerOptions = '-e USER=nextflow -e HOME=/tmp'
         publishDir = [
             path: locidex_merge_ref_directory_name,
             mode: params.publish_dir_mode,
@@ -39,6 +40,7 @@ process {
     }
 
     withName: LOCIDEX_MERGE_QUERY {
+        containerOptions = '-e USER=nextflow -e HOME=/tmp'
         publishDir = [
             path: locidex_merge_query_directory_name,
             mode: params.publish_dir_mode,

--- a/modules/local/locidex/merge/main.nf
+++ b/modules/local/locidex/merge/main.nf
@@ -6,8 +6,8 @@ process LOCIDEX_MERGE {
     fair true
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/locidex%3A0.3.0--pyhdfd78af_0' :
-        'biocontainers/locidex:0.3.0--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/locidex%3A0.4.0--pyhdfd78af_0' :
+        'biocontainers/locidex:0.4.0--pyhdfd78af_0' }"
 
 
     input:

--- a/tests/data/reports/sample1_manifest.mlst.json
+++ b/tests/data/reports/sample1_manifest.mlst.json
@@ -1,0 +1,22 @@
+{
+    "db_info": {},
+    "parameters": {
+        "mode": "normal",
+        "min_match_ident": 100,
+        "min_match_cov": 100,
+        "max_ambiguous": 0,
+        "max_internal_stops": 0
+    },
+    "data": {
+        "sample_name": "sample1",
+        "profile": {
+            "sample1": {
+                "l1": "1",
+                "l2": "1",
+                "l3": "1"
+            }
+        },
+        "seq_data": {}
+    },
+    "manifest": {}
+}

--- a/tests/data/reports/sampleQ.mlst.json
+++ b/tests/data/reports/sampleQ.mlst.json
@@ -1,0 +1,21 @@
+{
+    "db_info": {},
+    "parameters": {
+        "mode": "normal",
+        "min_match_ident": 100,
+        "min_match_cov": 100,
+        "max_ambiguous": 0,
+        "max_internal_stops": 0
+    },
+    "data": {
+        "sample_name": "sample1",
+        "profile": {
+            "sample1": {
+                "l1": "1",
+                "l2": "2",
+                "l3": "1"
+            }
+        },
+        "seq_data": {}
+    }
+}

--- a/tests/data/write/results.csv
+++ b/tests/data/write/results.csv
@@ -1,0 +1,5 @@
+sample,mlst_alleles
+sampleQ,/phac-nml/gasnomenclature/dev/tests/data/reports/sampleQ.mlst.json
+sample1,/phac-nml/gasnomenclature/dev/tests/data/reports/sample1_manifest.mlst.json
+sample2,/phac-nml/gasnomenclature/dev/tests/data/reports/sample2.mlst.json
+sample3,/phac-nml/gasnomenclature/dev/tests/data/reports/sample3.mlst.json

--- a/tests/modules/locidex_merge/main.nf.test
+++ b/tests/modules/locidex_merge/main.nf.test
@@ -1,0 +1,31 @@
+nextflow_process {
+    name "Test Process LOCIDEX_MERGE"
+    script "modules/local/locidex/merge/main.nf"
+    process "LOCIDEX_MERGE"
+
+    test("Test when LOCIDEX_MERGE handles MLST files with/without manifest") {
+        tag "LOCIDEX_MEGRE_multiple_files"
+        when {
+            process {
+                """
+                input[0] = Channel.of(
+                    [3, ["$baseDir/tests/data/reports/sampleQ.mlst.json","$baseDir/tests/data/reports/sample1_manifest.mlst.json", "$baseDir/tests/data/reports/sample2.mlst.json", "$baseDir/tests/data/reports/sample3.mlst.json"]])
+                input[1] = Channel.of("ref")
+                input[2] = Channel.of("$baseDir/tests/data/write/results.csv")
+                """
+            }
+
+            params {
+                outdir = "process_results"
+            }
+        }
+
+        then {
+            assert process.success
+            // Check the merged profiles files
+            def expected_profile = path("$baseDir/tests/data/profiles/expected-profile1.tsv")
+            def actual_profile = path("$launchDir/process_results/locidex/ref/profile_3.tsv")
+            assert actual_profile.text == expected_profile.text
+        }
+    }
+}

--- a/tests/nextflow.config
+++ b/tests/nextflow.config
@@ -20,3 +20,7 @@ iridanext.output.path = "${params.outdir}/iridanext.output.json"
 params.modules_testdata_base_path = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/'
 params.pipelines_testdata_base_path = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/test'
 params.outdir = "results"
+
+process {
+    containerOptions = '-e USER=nextflow -e HOME=/tmp'
+}


### PR DESCRIPTION
### `Updated`

- Upgraded `locidex` to [v.0.4.0](https://github.com/phac-nml/locidex/releases/tag/v0.4.0). [PR 33](https://github.com/phac-nml/fastmatchirida/pull/33)

### `Added`

- Added a process level `nf-test` for `LOCIDEX_MERGE` to confirm backward compatibility between MLST JSON files with and without a `"manfiest"` key. [PR 33](https://github.com/phac-nml/fastmatchirida/pull/33)