### PR TITLE
STRY0020426 - DFCT - fastmatchirida - fix container options for docker/singularity 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Run nf-test
         continue-on-error: ${{ matrix.NXF_VER == 'latest-everything' }}
         run: |
-          nf-test test -profile +docker
+          nf-test test --profile +docker
 
       - name: Nextflow run with test profile
         continue-on-error: ${{ matrix.NXF_VER == 'latest-everything' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Run nf-test
         continue-on-error: ${{ matrix.NXF_VER == 'latest-everything' }}
         run: |
-          nf-test test
+          nf-test test -profile +docker
 
       - name: Nextflow run with test profile
         continue-on-error: ${{ matrix.NXF_VER == 'latest-everything' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Set nextflow version 25.10.4 to replace 'latest-everything' to confirm compatibility with next IRIDA-Next nextflow version in `.github/workflows` for nf-test. [PR 44](https://github.com/phac-nml/fastmatchirida/pull/44)
 
+### `Fixed`
+
+- Fixed `containerOptions` string so the required options are only passed when using the `docker` profile (and not for `singularity`). [PR #45](https://github.com/phac-nml/fastmatchirida/pull/45)
+
 ## [0.4.2] - 2025-11-20
 
 ### `Changed`

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -30,7 +30,6 @@ process {
     ]
 
     withName: LOCIDEX_MERGE_REF {
-        containerOptions = '-e USER=nextflow -e HOME=/tmp'
         publishDir = [
             path: locidex_merge_ref_directory_name,
             mode: params.publish_dir_mode,
@@ -40,7 +39,6 @@ process {
     }
 
     withName: LOCIDEX_MERGE_QUERY {
-        containerOptions = '-e USER=nextflow -e HOME=/tmp'
         publishDir = [
             path: locidex_merge_query_directory_name,
             mode: params.publish_dir_mode,

--- a/modules/local/locidex/merge/main.nf
+++ b/modules/local/locidex/merge/main.nf
@@ -9,6 +9,8 @@ process LOCIDEX_MERGE {
         'https://depot.galaxyproject.org/singularity/locidex%3A0.4.0--pyhdfd78af_0' :
         'biocontainers/locidex:0.4.0--pyhdfd78af_0' }"
 
+    containerOptions "${task.ext.containerOptions ?: ''}"
+
 
     input:
     tuple val(batch_index), path(input_values) // [file(sample1), file(sample2), file(sample3), etc...]

--- a/nextflow.config
+++ b/nextflow.config
@@ -118,6 +118,7 @@ profiles {
         charliecloud.enabled   = false
         apptainer.enabled      = false
         docker.runOptions      = '-u $(id -u):$(id -g)'
+        process.ext.containerOptions = '-e USER=nextflow -e HOME=/tmp'
     }
     arm {
         docker.runOptions      = '-u $(id -u):$(id -g) --platform=linux/amd64'

--- a/nf-test.config
+++ b/nf-test.config
@@ -2,7 +2,6 @@ config {
     testsDir "tests"
     workDir System.getenv("NFT_WORKDIR") ?: ".nf-test"
     configFile "tests/nextflow.config"
-    profile "docker"
 
     // list of filenames or patterns that should be trigger a full test run
     triggers 'nextflow.config', 'nf-test.config', 'conf/test.config', 'tests/nextflow.config', 'tests/.nftignore', '.github/workflows/nf-test.yml'

--- a/tests/nextflow.config
+++ b/tests/nextflow.config
@@ -21,6 +21,3 @@ params.modules_testdata_base_path = 'https://raw.githubusercontent.com/nf-core/t
 params.pipelines_testdata_base_path = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/test'
 params.outdir = "results"
 
-process {
-    containerOptions = '-e USER=nextflow -e HOME=/tmp'
-}


### PR DESCRIPTION
Fixes up container options to only pass specific options when running with -profile docker.

This is a similar fix as was previously applied to the gasnomenclature pipeline: https://github.com/phac-nml/gasnomenclature/pull/88

_Note: GitHub CI tests only run using profile docker. I've ran the full test suite using profile singularity on my computer and it all passes. Also, I plan to update the GitHub CI files to the latest versions from nf-core in another PR._

## Acceptance criteria

1. - [x] Fix containerOptions string to only pass necessary options when using the docker profile (similar to previous fix in [Fixed up container options to only pass for locidex merge for docker by apetkau · Pull Request #75 · phac-nml/gasclustering](https://github.com/phac-nml/gasclustering/pull/75) )
2. - [x] Existing tests should continue to run when using either "-profile docker" or "-profile singularity"

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
