### PR TITLE
STRY0020434 - FastMatch Scheduled Output Files prefix and date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `--output_prefix`: a parameter for prepending a prefix to the results files. [PR #48](https://github.com/phac-nml/fastmatchirida/pull/48)
-- `--prefix_include_date`: a parameter for prending a date and time prefix in the UTC time zone to the results files. [PR #48](https://github.com/phac-nml/fastmatchirida/pull/48)
+- `--output_prefix`: a parameter for adding a prefix to the results files. [PR #48](https://github.com/phac-nml/fastmatchirida/pull/48)
+- `--prefix_include_date`: a parameter for adding a date and time prefix in the UTC time zone to the results files. [PR #48](https://github.com/phac-nml/fastmatchirida/pull/48)
 
 ### `Updated`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `--output_prefix`: a parameter for prepending a prefix to the results files. [PR #48](https://github.com/phac-nml/fastmatchirida/pull/48)
+- `--prefix_include_date`: a parameter for prending a date and time prefix in the UTC time zone to the results files. [PR #48](https://github.com/phac-nml/fastmatchirida/pull/48)
+
 ### `Updated`
 
 - Set nextflow version 25.10.4 to replace 'latest-everything' to confirm compatibility with next IRIDA-Next nextflow version in `.github/workflows` for nf-test. [PR 44](https://github.com/phac-nml/fastmatchirida/pull/44)

--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ An example of the what the contents of the IRIDA Next JSON file looks like for t
                 "path": "pipeline_info/software_versions.yml"
             },
             {
-                "path": "process/results.xlsx"
+                "path": "process/fastmatch.xlsx"
             },
             {
-                "path": "process/results.tsv"
+                "path": "process/fastmatch.tsv"
             },
             {
                 "path": "distances/profile_dists.run.json"

--- a/conf/iridanext.config
+++ b/conf/iridanext.config
@@ -13,8 +13,8 @@ iridanext {
                 "**/distances/profile_dists.results.tsv",
                 "**/distances/profile_dists.run.json",
                 "**/merged/locidex.merge.profile.tsv",
-                "**/process/results.tsv",
-                "**/process/results.xlsx",
+                "**/process/*fastmatch.tsv",
+                "**/process/*fastmatch.xlsx",
                 "**/pipeline_info/software_versions.yml",
                 "**/locidex/concat/query/MLST_error_report_concat_query.csv",
                 "**/locidex/concat/reference/MLST_error_report_concat_ref.csv"

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -25,7 +25,12 @@ process {
     locidex_concat_query_directory_name = [params.outdir , "locidex", "concat", "query"].join(File.separator)
 
     def addDatePrefix = { filename ->
-        def prefix = java.time.Instant.now().toString()
+        def pattern = "uuuu-MM-dd'T'HH:mm'Z'"
+        def formatter = java.time.format.DateTimeFormatter.ofPattern(pattern)
+        formatter = formatter.withZone(java.time.ZoneId.from(java.time.ZoneOffset.UTC))
+
+        def instant = java.time.Instant.now()
+        def prefix = formatter.format(instant)
         return "${prefix}_${filename}"
     }
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -15,6 +15,7 @@ process {
     // Publish directory names
     cluster_directory_name = "clusters"
     profile_dists_directory_name = "distances"
+    process_output_directory_name = "process"
     profile_dists_prefix = 'profile_dists.'
 
     locidex_merge_ref_directory_name = [params.outdir , "locidex", "merge"].join(File.separator)
@@ -22,6 +23,11 @@ process {
 
     locidex_concat_ref_directory_name = [params.outdir , "locidex", "concat", "reference"].join(File.separator)
     locidex_concat_query_directory_name = [params.outdir , "locidex", "concat", "query"].join(File.separator)
+
+    def addOutputPrefix = { filename ->
+        filename.equals("versions.yml") ? filename :
+        "${params.output_prefix}${filename}"
+    }
 
     publishDir = [
         path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
@@ -79,6 +85,14 @@ process {
             path: { "${params.outdir}/pipeline_info" },
             mode: params.publish_dir_mode,
             pattern: '*_versions.yml'
+        ]
+    }
+
+    withName: PROCESS_OUTPUT {
+        publishDir = [
+            path: { ["${params.outdir}", "${task.process_output_directory_name}"].join(File.separator) },
+            mode: params.publish_dir_mode,
+            saveAs: addOutputPrefix
         ]
     }
 }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -32,12 +32,13 @@ process {
         def formatter = java.time.format.DateTimeFormatter.ofPattern(pattern)
         formatter = formatter.withZone(java.time.ZoneId.from(java.time.ZoneOffset.UTC))
 
-        def prefix = formatter.format(instant)
+        def prefix = formatter.format(instant) // Re-use the same Instant.
         return "${prefix}_${filename}"
     }
 
     def addOutputPrefix = { filename ->
-        return "${params.output_prefix}${filename}"
+        def prefix = params.output_prefix ?: ""
+        return "${prefix}${filename}"
     }
 
     // Rename files created by the "process_output" module:
@@ -45,9 +46,9 @@ process {
         def renameMap = ["results.tsv": "fastmatch.tsv",
                          "results.xlsx": "fastmatch.xlsx"]
 
-        // Leave versions.yml unchanged:
+        // Don't save the versions file:
         if (filename.equals("versions.yml")) {
-            return filename
+            return null
         }
 
         def rename = filename
@@ -63,11 +64,9 @@ process {
         }
 
         // Add the output prefix:
-        // (Empty string by default)
         rename = addOutputPrefix(rename)
 
         return rename
-
     }
 
     publishDir = [

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -24,9 +24,23 @@ process {
     locidex_concat_ref_directory_name = [params.outdir , "locidex", "concat", "reference"].join(File.separator)
     locidex_concat_query_directory_name = [params.outdir , "locidex", "concat", "query"].join(File.separator)
 
+    def addDatePrefix = { filename ->
+        def prefix = java.time.Instant.now().toString()
+        return "${prefix}_${filename}"
+    }
+
     def addOutputPrefix = { filename ->
-        filename.equals("versions.yml") ? filename :
-        "${params.output_prefix}${filename}"
+        return "${params.output_prefix}${filename}"
+    }
+
+    def addProcessPrefix = { filename ->
+        if (filename.equals("versions.yml")) {
+            return filename
+        } else if (params.prefix_include_date) {
+            return addOutputPrefix(addDatePrefix(filename))
+        } else {
+            return addOutputPrefix(filename)
+        }
     }
 
     publishDir = [
@@ -92,7 +106,7 @@ process {
         publishDir = [
             path: { ["${params.outdir}", "${task.process_output_directory_name}"].join(File.separator) },
             mode: params.publish_dir_mode,
-            saveAs: addOutputPrefix
+            saveAs: addProcessPrefix
         ]
     }
 }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -24,12 +24,14 @@ process {
     locidex_concat_ref_directory_name = [params.outdir , "locidex", "concat", "reference"].join(File.separator)
     locidex_concat_query_directory_name = [params.outdir , "locidex", "concat", "query"].join(File.separator)
 
+    // The current date and time:
+    def instant = java.time.Instant.now() // Generating the current date and time once.
+
     def addDatePrefix = { filename ->
         def pattern = "uuuu-MM-dd'T'HH:mm'Z'"
         def formatter = java.time.format.DateTimeFormatter.ofPattern(pattern)
         formatter = formatter.withZone(java.time.ZoneId.from(java.time.ZoneOffset.UTC))
 
-        def instant = java.time.Instant.now()
         def prefix = formatter.format(instant)
         return "${prefix}_${filename}"
     }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -38,14 +38,34 @@ process {
         return "${params.output_prefix}${filename}"
     }
 
-    def addProcessPrefix = { filename ->
+    // Rename files created by the "process_output" module:
+    def renameProcessFiles = { filename ->
+        def renameMap = ["results.tsv": "fastmatch.tsv",
+                         "results.xlsx": "fastmatch.xlsx"]
+
+        // Leave versions.yml unchanged:
         if (filename.equals("versions.yml")) {
             return filename
-        } else if (params.prefix_include_date) {
-            return addOutputPrefix(addDatePrefix(filename))
-        } else {
-            return addOutputPrefix(filename)
         }
+
+        def rename = filename
+
+        // Rename files before adding prefixes:
+        if (renameMap.containsKey(rename)) {
+            rename = renameMap[rename]
+        }
+
+        // Add a date prefix if requested:
+        if (params.prefix_include_date) {
+            rename = addDatePrefix(rename)
+        }
+
+        // Add the output prefix:
+        // (Empty string by default)
+        rename = addOutputPrefix(rename)
+
+        return rename
+
     }
 
     publishDir = [
@@ -111,7 +131,7 @@ process {
         publishDir = [
             path: { ["${params.outdir}", "${task.process_output_directory_name}"].join(File.separator) },
             mode: params.publish_dir_mode,
-            saveAs: addProcessPrefix
+            saveAs: renameProcessFiles
         ]
     }
 }

--- a/docs/output.md
+++ b/docs/output.md
@@ -94,8 +94,13 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
 <summary>Output files</summary>
 
 - `process/`
-  - Pairwise distance results meeting specifications in TSV-format: `results.tsv`
-  - Pairwise distance results meeting specifications in XLSX-format: `results.xlsx`
+  - Pairwise distance results meeting specifications in TSV-format (file path may have a prefix added): `fastmatch.tsv`
+  - Pairwise distance results meeting specifications in XLSX-format (file path may have a prefix added): `fastmatch.xlsx`
+
+The following parameters may be used (independently or together) to modify the prefix of the above file paths:
+
+- `--output_prefix`: Prepends the specified prefix to the TSV and XLSX-format files above. For example, `--output_prefix PREFIX_` will result in the following file paths: `PREFIX_fastmatch.tsv` and `PREFIX_fastmatch.xlsx`.
+- `--prefix_include_date`: Prepends the date and time in the UTC time zone. For example, `2026-03-31T13:32Z_fastmatch.tsv` and `2026-03-31T13:32Z_fastmatch.xlsx`.
 
 </details>
 

--- a/modules/local/process_output/main.nf
+++ b/modules/local/process_output/main.nf
@@ -10,8 +10,8 @@ process PROCESS_OUTPUT {
     val threshold
 
     output:
-    path "fastmatch.tsv", emit: tsv
-    path "fastmatch.xlsx", emit: excel
+    path "results.tsv", emit: tsv
+    path "results.xlsx", emit: excel
     path "versions.yml", emit: versions
 
     when:
@@ -23,7 +23,7 @@ process PROCESS_OUTPUT {
     process_output.py \\
         $args \\
         --input $distances \\
-        --output fastmatch \\
+        --output results \\
         --threshold $threshold
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/process_output/main.nf
+++ b/modules/local/process_output/main.nf
@@ -10,8 +10,8 @@ process PROCESS_OUTPUT {
     val threshold
 
     output:
-    path "results.tsv", emit: tsv
-    path "results.xlsx", emit: excel
+    path "fastmatch.tsv", emit: tsv
+    path "fastmatch.xlsx", emit: excel
     path "versions.yml", emit: versions
 
     when:
@@ -23,7 +23,7 @@ process PROCESS_OUTPUT {
     process_output.py \\
         $args \\
         --input $distances \\
-        --output results \\
+        --output fastmatch \\
         --threshold $threshold
 
     cat <<-END_VERSIONS > versions.yml

--- a/nextflow.config
+++ b/nextflow.config
@@ -79,6 +79,7 @@ params {
 
     // Output
     output_prefix = ""
+    prefix_include_date = false
 }
 
 // Load base.config by default for all pipelines

--- a/nextflow.config
+++ b/nextflow.config
@@ -76,6 +76,9 @@ params {
     metadata_14_header = "metadata_14"
     metadata_15_header = "metadata_15"
     metadata_16_header = "metadata_16"
+
+    // Output
+    output_prefix = ""
 }
 
 // Load base.config by default for all pipelines

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -39,11 +39,12 @@
                 },
                 "output_prefix": {
                     "type": "string",
-                    "description": "Adds a prefix to output files.",
+                    "description": "Specifies a prefix for the fastmatch results file names.",
                     "pattern": "^[a-zA-Z0-9_.-]+$"
                 },
                 "prefix_include_date": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Whether or not to add a date and time prefix to the fastmatch results files."
                 }
             }
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -36,6 +36,11 @@
                     "help_text": "Set this parameter to your e-mail address to get a summary e-mail with details of the run sent to you when the workflow exits. If set in your user config file (`~/.nextflow/config`) then you don't need to specify this on the command line for every run.",
                     "pattern": "^([a-zA-Z0-9_\\-\\.]+)@([a-zA-Z0-9_\\-\\.]+)\\.([a-zA-Z]{2,5})$",
                     "hidden": true
+                },
+                "output_prefix": {
+                    "type": "string",
+                    "description": "Adds a prefix to output files.",
+                    "pattern": "^[a-zA-Z0-9_.-]+$"
                 }
             }
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -41,6 +41,9 @@
                     "type": "string",
                     "description": "Adds a prefix to output files.",
                     "pattern": "^[a-zA-Z0-9_.-]+$"
+                },
+                "prefix_include_date": {
+                    "type": "boolean"
                 }
             }
         },

--- a/tests/.nftignore
+++ b/tests/.nftignore
@@ -13,4 +13,3 @@ pipeline_info/*.{html,json,txt,yml}
 distances/profile_dists.run.json
 iridanext.output.json
 process/fastmatch.xlsx
-process/fastmatch.tsv

--- a/tests/.nftignore
+++ b/tests/.nftignore
@@ -12,4 +12,5 @@ fastqc/*_fastqc.{html,zip}
 pipeline_info/*.{html,json,txt,yml}
 distances/profile_dists.run.json
 iridanext.output.json
-process/results.xlsx
+process/fastmatch.xlsx
+process/fastmatch.tsv

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -56,8 +56,9 @@
                 "pipeline_info",
                 "pipeline_info/software_versions.yml",
                 "process",
-                "process/results.tsv",
-                "process/results.xlsx",
+                "process/fastmatch.tsv",
+                "process/fastmatch.xlsx",
+                "process/versions.yml",
                 "write",
                 "write/results.csv"
             ],
@@ -75,14 +76,14 @@
                 "profile_1.tsv:md5,a50a17facefed930d5d894d1175d31a5",
                 "MLST_error_report_1.csv:md5,f6689b46a8f71e85ee04acc80800ad84",
                 "profile_1.tsv:md5,0e36755dc241bc2645a1c53ab7fcac1e",
-                "results.tsv:md5,e3c65463cab632a9e1b2a75c8718847a",
+                "versions.yml:md5,76504de2c239300b7e292f76eb427517",
                 "results.csv:md5,7ea90cfb97fb6e104db37c21fbed1c67"
             ]
         ],
-        "timestamp": "2026-03-26T15:06:13.255202652",
         "meta": {
-            "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
-        }
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.0"
+        },
+        "timestamp": "2026-03-31T10:35:52.027213345"
     }
 }

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -58,7 +58,6 @@
                 "process",
                 "process/fastmatch.tsv",
                 "process/fastmatch.xlsx",
-                "process/versions.yml",
                 "write",
                 "write/results.csv"
             ],
@@ -76,7 +75,7 @@
                 "profile_1.tsv:md5,a50a17facefed930d5d894d1175d31a5",
                 "MLST_error_report_1.csv:md5,f6689b46a8f71e85ee04acc80800ad84",
                 "profile_1.tsv:md5,0e36755dc241bc2645a1c53ab7fcac1e",
-                "versions.yml:md5,76504de2c239300b7e292f76eb427517",
+                "fastmatch.tsv:md5,e3c65463cab632a9e1b2a75c8718847a",
                 "results.csv:md5,7ea90cfb97fb6e104db37c21fbed1c67"
             ]
         ],
@@ -84,6 +83,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2026-03-31T10:35:52.027213345"
+        "timestamp": "2026-03-31T13:58:10.721966693"
     }
 }

--- a/tests/pipelines/integration.nf.test
+++ b/tests/pipelines/integration.nf.test
@@ -56,9 +56,9 @@ nextflow_pipeline {
             assert merged_reference.text.contains("sample2\t1\t2\t1\t1\t1\n")
 
             // Check Processed Output
-            def processed_output_tsv = path("$launchDir/results/process/results.tsv")
+            def processed_output_tsv = path("$launchDir/results/process/fastmatch.tsv")
             assert processed_output_tsv.exists()
-            def processed_output_xlsx = path("$launchDir/results/process/results.xlsx")
+            def processed_output_xlsx = path("$launchDir/results/process/fastmatch.xlsx")
             assert processed_output_xlsx.exists()
 
             assert processed_output_tsv.text.contains("Query ID\tQuery Sample Name\tReference ID\tReference Sample Name\tDistance\tmetadata_1\tmetadata_2\tmetadata_3\tmetadata_4\tmetadata_5\tmetadata_6\tmetadata_7\tmetadata_8\tmetadata_9\tmetadata_10\tmetadata_11\tmetadata_12\tmetadata_13\tmetadata_14\tmetadata_15\tmetadata_16")
@@ -140,9 +140,9 @@ nextflow_pipeline {
             assert merged_reference.text.contains("sample2\t1\t2\t1\t1\t1\n")
 
             // Check Processed Output
-            def processed_output_tsv = path("$launchDir/results/process/results.tsv")
+            def processed_output_tsv = path("$launchDir/results/process/fastmatch.tsv")
             assert processed_output_tsv.exists()
-            def processed_output_xlsx = path("$launchDir/results/process/results.xlsx")
+            def processed_output_xlsx = path("$launchDir/results/process/fastmatch.xlsx")
             assert processed_output_xlsx.exists()
 
             assert processed_output_tsv.text.contains("Query ID\tQuery Sample Name\tReference ID\tReference Sample Name\tDistance\tmetadata_1\tmetadata_2\tmetadata_3\tmetadata_4\tmetadata_5\tmetadata_6\tmetadata_7\tmetadata_8")
@@ -234,9 +234,9 @@ nextflow_pipeline {
             assert merged_reference.text.contains("sample2\t1\t2\t1\t1\t1\n")
 
             // Check Processed Output
-            def processed_output_tsv = path("$launchDir/results/process/results.tsv")
+            def processed_output_tsv = path("$launchDir/results/process/fastmatch.tsv")
             assert processed_output_tsv.exists()
-            def processed_output_xlsx = path("$launchDir/results/process/results.xlsx")
+            def processed_output_xlsx = path("$launchDir/results/process/fastmatch.xlsx")
             assert processed_output_xlsx.exists()
 
             assert processed_output_tsv.text.contains("Query ID\tQuery Sample Name\tReference ID\tReference Sample Name\tDistance\tmetadata_1\tmetadata_2\tmetadata_3\tmetadata_4\tmetadata_5\tmetadata_6\tmetadata_7\tmetadata_8")
@@ -335,9 +335,9 @@ nextflow_pipeline {
             assert merged_reference.text.contains("sample2\t1\t2\t1\t1\t1\n")
 
             // Check Processed Output
-            def processed_output_tsv = path("$launchDir/results/process/results.tsv")
+            def processed_output_tsv = path("$launchDir/results/process/fastmatch.tsv")
             assert processed_output_tsv.exists()
-            def processed_output_xlsx = path("$launchDir/results/process/results.xlsx")
+            def processed_output_xlsx = path("$launchDir/results/process/fastmatch.xlsx")
             assert processed_output_xlsx.exists()
 
             assert processed_output_tsv.text.contains("Query ID\tQuery Sample Name\tReference ID\tReference Sample Name\tDistance\torganism\tsubtype\tcountry\tserovar\tage\tdate\tsource\tspecial")
@@ -419,9 +419,9 @@ nextflow_pipeline {
             assert merged_reference.text.contains("sample2\t1\t2\t1\t1\t1\n")
 
             // Check Processed Output
-            def processed_output_tsv = path("$launchDir/results/process/results.tsv")
+            def processed_output_tsv = path("$launchDir/results/process/fastmatch.tsv")
             assert processed_output_tsv.exists()
-            def processed_output_xlsx = path("$launchDir/results/process/results.xlsx")
+            def processed_output_xlsx = path("$launchDir/results/process/fastmatch.xlsx")
             assert processed_output_xlsx.exists()
 
             assert processed_output_tsv.text.contains("Query ID\tQuery Sample Name\tReference ID\tReference Sample Name\tDistance\tmetadata_1\tmetadata_2\tmetadata_3\tmetadata_4\tmetadata_5\tmetadata_6\tmetadata_7\tmetadata_8")
@@ -507,9 +507,9 @@ nextflow_pipeline {
             assert merged_reference.text.contains("sample2\t1\t2\t-\t-\t-\n")
 
             // Check Processed Output
-            def processed_output_tsv = path("$launchDir/results/process/results.tsv")
+            def processed_output_tsv = path("$launchDir/results/process/fastmatch.tsv")
             assert processed_output_tsv.exists()
-            def processed_output_xlsx = path("$launchDir/results/process/results.xlsx")
+            def processed_output_xlsx = path("$launchDir/results/process/fastmatch.xlsx")
             assert processed_output_xlsx.exists()
 
             assert processed_output_tsv.text.contains("Query ID\tQuery Sample Name\tReference ID\tReference Sample Name\tDistance\tmetadata_1\tmetadata_2\tmetadata_3\tmetadata_4\tmetadata_5\tmetadata_6\tmetadata_7\tmetadata_8")
@@ -599,9 +599,9 @@ nextflow_pipeline {
             assert merged_reference.text.contains("sample2\t1\t2\t-\t-\t-\n")
 
             // Check Processed Output
-            def processed_output_tsv = path("$launchDir/results/process/results.tsv")
+            def processed_output_tsv = path("$launchDir/results/process/fastmatch.tsv")
             assert processed_output_tsv.exists()
-            def processed_output_xlsx = path("$launchDir/results/process/results.xlsx")
+            def processed_output_xlsx = path("$launchDir/results/process/fastmatch.xlsx")
             assert processed_output_xlsx.exists()
 
             assert processed_output_tsv.text.contains("Query ID\tQuery Sample Name\tReference ID\tReference Sample Name\tDistance\tmetadata_1\tmetadata_2\tmetadata_3\tmetadata_4\tmetadata_5\tmetadata_6\tmetadata_7\tmetadata_8")
@@ -696,9 +696,9 @@ nextflow_pipeline {
             assert merged_reference.text.contains("sample2\t1\t2\t-\t-\t-\n")
 
             // Check Processed Output
-            def processed_output_tsv = path("$launchDir/results/process/results.tsv")
+            def processed_output_tsv = path("$launchDir/results/process/fastmatch.tsv")
             assert processed_output_tsv.exists()
-            def processed_output_xlsx = path("$launchDir/results/process/results.xlsx")
+            def processed_output_xlsx = path("$launchDir/results/process/fastmatch.xlsx")
             assert processed_output_xlsx.exists()
 
             assert processed_output_tsv.text.contains("Query ID\tQuery Sample Name\tReference ID\tReference Sample Name\tDistance\tmetadata_1\tmetadata_2\tmetadata_3\tmetadata_4\tmetadata_5\tmetadata_6\tmetadata_7\tmetadata_8")
@@ -792,9 +792,9 @@ nextflow_pipeline {
             assert merged_reference.text.contains("sample2\t1\t2\t-\t-\t-\n")
 
             // Check Processed Output
-            def processed_output_tsv = path("$launchDir/results/process/results.tsv")
+            def processed_output_tsv = path("$launchDir/results/process/fastmatch.tsv")
             assert processed_output_tsv.exists()
-            def processed_output_xlsx = path("$launchDir/results/process/results.xlsx")
+            def processed_output_xlsx = path("$launchDir/results/process/fastmatch.xlsx")
             assert processed_output_xlsx.exists()
 
             assert processed_output_tsv.text.contains("Query ID\tQuery Sample Name\tReference ID\tReference Sample Name\tDistance\tmetadata_1\tmetadata_2\tmetadata_3\tmetadata_4\tmetadata_5\tmetadata_6\tmetadata_7\tmetadata_8")
@@ -889,9 +889,9 @@ nextflow_pipeline {
             assert merged_reference.text.contains("sample2\t1\t2\t-\t-\t-\n")
 
             // Check Processed Output
-            def processed_output_tsv = path("$launchDir/results/process/results.tsv")
+            def processed_output_tsv = path("$launchDir/results/process/fastmatch.tsv")
             assert processed_output_tsv.exists()
-            def processed_output_xlsx = path("$launchDir/results/process/results.xlsx")
+            def processed_output_xlsx = path("$launchDir/results/process/fastmatch.xlsx")
             assert processed_output_xlsx.exists()
 
             assert processed_output_tsv.text.contains("Query ID\tQuery Sample Name\tReference ID\tReference Sample Name\tDistance\tmetadata_1\tmetadata_2\tmetadata_3\tmetadata_4\tmetadata_5\tmetadata_6\tmetadata_7\tmetadata_8")
@@ -970,9 +970,9 @@ nextflow_pipeline {
             assert merged_reference.text.contains("sample2\t1\t2\t-\t-\t-\n")
 
             // Check Processed Output
-            def processed_output_tsv = path("$launchDir/results/process/results.tsv")
+            def processed_output_tsv = path("$launchDir/results/process/fastmatch.tsv")
             assert processed_output_tsv.exists()
-            def processed_output_xlsx = path("$launchDir/results/process/results.xlsx")
+            def processed_output_xlsx = path("$launchDir/results/process/fastmatch.xlsx")
             assert processed_output_xlsx.exists()
 
             assert processed_output_tsv.text.contains("Query ID\tQuery Sample Name\tReference ID\tReference Sample Name\tDistance\tmetadata_1\tmetadata_2\tmetadata_3\tmetadata_4\tmetadata_5\tmetadata_6\tmetadata_7\tmetadata_8")
@@ -1051,9 +1051,9 @@ nextflow_pipeline {
             assert merged_reference.text.contains("sample2\t1\t2\t-\t-\t-\n")
 
             // Check Processed Output
-            def processed_output_tsv = path("$launchDir/results/process/results.tsv")
+            def processed_output_tsv = path("$launchDir/results/process/fastmatch.tsv")
             assert processed_output_tsv.exists()
-            def processed_output_xlsx = path("$launchDir/results/process/results.xlsx")
+            def processed_output_xlsx = path("$launchDir/results/process/fastmatch.xlsx")
             assert processed_output_xlsx.exists()
 
             assert processed_output_tsv.text.contains("Query ID\tQuery Sample Name\tReference ID\tReference Sample Name\tDistance\tmetadata_1\tmetadata_2\tmetadata_3\tmetadata_4\tmetadata_5\tmetadata_6\tmetadata_7\tmetadata_8")
@@ -1155,9 +1155,9 @@ nextflow_pipeline {
             assert merge_tsv_content.text.split('\n').any { line -> line ==~ /^sampleP.*\/sampleP_sample4\.mlst\.json$/}
 
             // Check Processed Output
-            def processed_output_tsv = path("$launchDir/results/process/results.tsv")
+            def processed_output_tsv = path("$launchDir/results/process/fastmatch.tsv")
             assert processed_output_tsv.exists()
-            def processed_output_xlsx = path("$launchDir/results/process/results.xlsx")
+            def processed_output_xlsx = path("$launchDir/results/process/fastmatch.xlsx")
             assert processed_output_xlsx.exists()
 
             assert processed_output_tsv.text.contains("Query ID\tQuery Sample Name\tReference ID\tReference Sample Name\tDistance\tmetadata_1\tmetadata_2\tmetadata_3\tmetadata_4\tmetadata_5\tmetadata_6\tmetadata_7\tmetadata_8")
@@ -1198,9 +1198,9 @@ nextflow_pipeline {
             assert merge_tsv_content.text.split('\n').any { line -> line ==~ /^sampleP.*\/sampleP_sample4\.mlst\.json$/}
 
             // Check Processed Output
-            def processed_output_tsv = path("$launchDir/results/process/results.tsv")
+            def processed_output_tsv = path("$launchDir/results/process/fastmatch.tsv")
             assert processed_output_tsv.exists()
-            def processed_output_xlsx = path("$launchDir/results/process/results.xlsx")
+            def processed_output_xlsx = path("$launchDir/results/process/fastmatch.xlsx")
             assert processed_output_xlsx.exists()
 
             assert processed_output_tsv.text.contains("Query ID\tQuery Sample Name\tReference ID\tReference Sample Name\tDistance\tmetadata_1\tmetadata_2\tmetadata_3\tmetadata_4\tmetadata_5\tmetadata_6\tmetadata_7\tmetadata_8")
@@ -1231,9 +1231,9 @@ nextflow_pipeline {
 
 
             // Check Processed Output
-            def processed_output_tsv = path("$launchDir/results/process/results.tsv")
+            def processed_output_tsv = path("$launchDir/results/process/fastmatch.tsv")
             assert processed_output_tsv.exists()
-            def processed_output_xlsx = path("$launchDir/results/process/results.xlsx")
+            def processed_output_xlsx = path("$launchDir/results/process/fastmatch.xlsx")
             assert processed_output_xlsx.exists()
 
             assert processed_output_tsv.text.contains("Query ID\tQuery Sample Name\tReference ID\tReference Sample Name\tDistance\tmetadata_1\tmetadata_2\tmetadata_3\tmetadata_4\tmetadata_5\tmetadata_6\tmetadata_7\tmetadata_8")

--- a/tests/pipelines/rename.nf.test
+++ b/tests/pipelines/rename.nf.test
@@ -1,0 +1,161 @@
+nextflow_pipeline {
+
+    name "FastMatch Rename Testing"
+    script "main.nf"
+
+    test("Rename Process: No Prefix") {
+        tag "pipeline_rename_process"
+        tag "pipeline_rename_process_no_prefix"
+
+        when {
+            params {
+                input = "$baseDir/tests/data/samplesheets/basic.csv"
+                outdir = "results"
+
+                pd_distm = "hamming"
+                threshold = 1
+
+                output_prefix = ""
+                prefix_include_date = false
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert path("$launchDir/results").exists()
+
+            assert path("$launchDir/results/append/distances_and_metadata.tsv").exists()
+            assert path("$launchDir/results/locidex/concat/query/profile_concat_query.tsv").exists()
+            assert path("$launchDir/results/locidex/concat/reference/profile_concat_ref.tsv").exists()
+            assert path("$launchDir/results/process/fastmatch.tsv").exists()
+            assert path("$launchDir/results/process/fastmatch.xlsx").exists()
+            assert path("$launchDir/results/distances/profile_dists.results.tsv").exists()
+        }
+    }
+
+    test("Rename Process: Add Prefix") {
+        tag "pipeline_rename_process"
+        tag "pipeline_rename_process_add_prefix"
+
+        when {
+            params {
+                input = "$baseDir/tests/data/samplesheets/basic.csv"
+                outdir = "results"
+
+                pd_distm = "hamming"
+                threshold = 1
+
+                output_prefix = "PREFIX_"
+                prefix_include_date = false
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert path("$launchDir/results").exists()
+
+            assert path("$launchDir/results/append/distances_and_metadata.tsv").exists()
+            assert path("$launchDir/results/locidex/concat/query/profile_concat_query.tsv").exists()
+            assert path("$launchDir/results/locidex/concat/reference/profile_concat_ref.tsv").exists()
+            assert path("$launchDir/results/process/PREFIX_fastmatch.tsv").exists()
+            assert path("$launchDir/results/process/PREFIX_fastmatch.xlsx").exists()
+            assert path("$launchDir/results/distances/profile_dists.results.tsv").exists()
+        }
+    }
+
+    test("Rename Process: Add Date Prefix") {
+        tag "pipeline_rename_process"
+        tag "pipeline_rename_process_add_date_prefix"
+
+        when {
+            params {
+                input = "$baseDir/tests/data/samplesheets/basic.csv"
+                outdir = "results"
+
+                pd_distm = "hamming"
+                threshold = 1
+
+                output_prefix = ""
+                prefix_include_date = true
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert path("$launchDir/results").exists()
+
+            assert path("$launchDir/results/append/distances_and_metadata.tsv").exists()
+            assert path("$launchDir/results/locidex/concat/query/profile_concat_query.tsv").exists()
+            assert path("$launchDir/results/locidex/concat/reference/profile_concat_ref.tsv").exists()
+            assert path("$launchDir/results/distances/profile_dists.results.tsv").exists()
+
+            def filepaths = path("$launchDir/results/process/").list()
+
+            // FASTMATCH TSV
+            def fastmatch_tsv_path = filepaths.find(filepath -> filepath.toString().endsWith("fastmatch.tsv"))
+            assert fastmatch_tsv_path != null
+
+            def fastmatch_tsv_path_last_element = fastmatch_tsv_path.getName(fastmatch_tsv_path.getNameCount() - 1)
+            // Example: 2026-03-31T14:54Z_fastmatch.tsv
+            def fastmatch_tsv_regex = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}Z_fastmatch\.tsv/
+            assert fastmatch_tsv_path_last_element.toString().matches(fastmatch_tsv_regex)
+
+            // FASTMATCH XLSX
+            def fastmatch_xlsx_path = filepaths.find(filepath -> filepath.toString().endsWith("fastmatch.xlsx"))
+            assert fastmatch_xlsx_path != null
+
+            def fastmatch_xlsx_path_last_element = fastmatch_xlsx_path.getName(fastmatch_xlsx_path.getNameCount() - 1)
+            // Example: 2026-03-31T14:54Z_fastmatch.xlsx
+            def fastmatch_xlsx_regex = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}Z_fastmatch\.xlsx/
+            assert fastmatch_xlsx_path_last_element.toString().matches(fastmatch_xlsx_regex)
+        }
+    }
+
+    test("Rename Process: Add Prefix and Date Prefix") {
+        tag "pipeline_rename_process"
+        tag "pipeline_rename_process_add_prefix_and_date_prefix"
+
+        when {
+            params {
+                input = "$baseDir/tests/data/samplesheets/basic.csv"
+                outdir = "results"
+
+                pd_distm = "hamming"
+                threshold = 1
+
+                output_prefix = "PREFIX_"
+                prefix_include_date = true
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert path("$launchDir/results").exists()
+
+            assert path("$launchDir/results/append/distances_and_metadata.tsv").exists()
+            assert path("$launchDir/results/locidex/concat/query/profile_concat_query.tsv").exists()
+            assert path("$launchDir/results/locidex/concat/reference/profile_concat_ref.tsv").exists()
+            assert path("$launchDir/results/distances/profile_dists.results.tsv").exists()
+
+            def filepaths = path("$launchDir/results/process/").list()
+
+            // FASTMATCH TSV
+            def fastmatch_tsv_path = filepaths.find(filepath -> filepath.toString().endsWith("fastmatch.tsv"))
+            assert fastmatch_tsv_path != null
+
+            def fastmatch_tsv_path_last_element = fastmatch_tsv_path.getName(fastmatch_tsv_path.getNameCount() - 1)
+            // Example: PREFIX_2026-03-31T14:54Z_fastmatch.tsv
+            def fastmatch_tsv_regex = /PREFIX_\d{4}-\d{2}-\d{2}T\d{2}:\d{2}Z_fastmatch\.tsv/
+            assert fastmatch_tsv_path_last_element.toString().matches(fastmatch_tsv_regex)
+
+            // FASTMATCH XLSX
+            def fastmatch_xlsx_path = filepaths.find(filepath -> filepath.toString().endsWith("fastmatch.xlsx"))
+            assert fastmatch_xlsx_path != null
+
+            def fastmatch_xlsx_path_last_element = fastmatch_xlsx_path.getName(fastmatch_xlsx_path.getNameCount() - 1)
+            // Example: PREFIX_2026-03-31T14:54Z_fastmatch.xlsx
+            def fastmatch_xlsx_regex = /PREFIX_\d{4}-\d{2}-\d{2}T\d{2}:\d{2}Z_fastmatch\.xlsx/
+            assert fastmatch_xlsx_path_last_element.toString().matches(fastmatch_xlsx_regex)
+        }
+    }
+}


### PR DESCRIPTION
**Description**

As a pipeline developer, I would like to add parameters to include a prefix and date to the output files of fastmatch, so that when configured to run as a scheduled pipeline the output files are easier to keep organized.

**Acceptance Criteria**

- [x] Rename "results.xlsx" and "results.tsv" to "fastmatch.xlsx" and "fastmatch.tsv"
- [x] Setup parameter "--output_prefix" that can be used to add a prefix to output files
  - [x] E.g,. Instead of "results.xlsx" it adds "Listeria_results.xlsx" assuming prefix is set to "Listeria_"
  - [x] Default value should be "null" or no prefix
- [x] Add parameter "--prefix_include_date" which controls if a date/time like "YYYY-MM-DDTHH:MMZ" is added to the prefix string. Default false.
  - [x] We need hour and minute resolution since output files could be generated multiple times a day.
  - [x] Format should be ISO 8601 (see [ISO 8601 - Wikipedia](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations) ). The "T" separates date from time and "Z" at end is for UTC timezone.
  - [x] Should use UTC as time-zone (or whatever timezone in Azure)
- [x] Only need to add prefix to output files stored in IRIDA Next [fastmatch.xlsx] (though could add prefix to all outputs)
- [x] Include tests to make sure adding prefix to outputs works
- [x] Final output file if given "--output_prefix Listeria" and "--prefix_include_date" should be something like "Listeria_2026-03-27T13:00Z_fastmatch.xlsx"

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/phac-nml/fastmatchirida/tree/main/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
